### PR TITLE
Configure cascade deletion on models associated to votings

### DIFF
--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,6 @@
 class Option < ApplicationRecord
   belongs_to :question
-  has_many :votes
+  has_many :votes, dependent: :destroy
   has_many :groups, through: :votes
 
   validates_presence_of :title

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,6 @@
 class Question < ApplicationRecord
   belongs_to :voting
-  has_many :options
+  has_many :options, dependent: :destroy
   has_many :votes, through: :options
 
   accepts_nested_attributes_for :options,  reject_if: :all_blank, allow_destroy: true

--- a/app/models/voting.rb
+++ b/app/models/voting.rb
@@ -3,8 +3,8 @@
 class Voting < ApplicationRecord
   enum status: %i[draft open finished]
 
-  has_many :questions
-  has_many :vote_submissions
+  has_many :questions, dependent: :destroy
+  has_many :vote_submissions, dependent: :destroy
   has_many :groups, through: :vote_submissions
 
   validates_presence_of :title, :status


### PR DESCRIPTION
### What

We need to destroy all models associated with a voting object when it is destroyed.