### PR TITLE
Fix last login tracking using API

### DIFF
--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -12,6 +12,9 @@ module Api
           @user = User.with_valid_auth_token.find_by!(auth_token: user_params[:auth_token])
           bypass_sign_in(@user)
 
+          @user.update_tracked_fields(request)
+          @user.save!
+
           super
         end
 

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -8,7 +8,7 @@
       group.number,
       group.available_votes,
       group.user.auth_token,
-      group.user.last_sign_in_at || 'Never',
+      group.user.last_sign_in_at ? distance_of_time_in_words(group.user.last_sign_in_at, Time.now) : 'Never',
       link_to('Edit', edit_group_path(group)),
       link_to('Destroy', group, method: :delete, data: { confirm: 'Are you sure?' })
     ] %>


### PR DESCRIPTION
### What

Last login tracking was not working properly for API login

### How

- Manually trigger the tracking of user data after API sign in
- Modify the groups list page to display the last sign in datetime in relative terms.