### PR TITLE
Skip db creation step from docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,6 @@ services:
       - migration
   migration:
     build: .
-    command: "bundle exec rake db:create db:migrate"
+    command: "bundle exec rake db:migrate"
     depends_on:
       - db


### PR DESCRIPTION
docker-compose could not run the migrations because there was an error creating the database