### PR TITLE
Make group number optional

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -23,6 +23,6 @@ class Group < ApplicationRecord
   private
 
   def create_user
-    self.user_id ||= User.create(email: "test+#{number}@example.com", password: SecureRandom.uuid).id
+    self.user_id ||= User.create(email: "test+#{SecureRandom.uuid}@example.com", password: SecureRandom.uuid).id
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,9 +6,9 @@ class Group < ApplicationRecord
   has_many :votes
 
   # Validations
-  validates_presence_of :name, :number, :available_votes
-  validates_uniqueness_of :name, :number
-  validates_numericality_of :number, :available_votes, greater_than_or_equal_to: 1
+  validates_presence_of :name, :available_votes
+  validates_uniqueness_of :name
+  validates_numericality_of :available_votes, greater_than_or_equal_to: 1
 
   before_validation :create_user
 

--- a/db/migrate/20200506221148_make_group_number_optional.rb
+++ b/db/migrate/20200506221148_make_group_number_optional.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MakeGroupNumberOptional < ActiveRecord::Migration[6.0]
+  def up
+    change_column :groups, :number, :integer, null: true
+    remove_index :groups, :number
+  end
+
+  def down
+    change_column :groups, :number, :integer, null: false
+    add_index :groups, :number, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_185343) do
+ActiveRecord::Schema.define(version: 2020_05_06_221148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -18,13 +18,12 @@ ActiveRecord::Schema.define(version: 2020_05_05_185343) do
 
   create_table "groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
-    t.integer "number", null: false
+    t.integer "number"
     t.integer "available_votes", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "user_id"
     t.index ["name"], name: "index_groups_on_name", unique: true
-    t.index ["number"], name: "index_groups_on_number", unique: true
     t.index ["user_id"], name: "index_groups_on_user_id", unique: true
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Group, type: :model do
       it 'creates and assigns a user to the group' do
         expect(create(:group).user).to be_a(User)
       end
+
+      it 'the email of the fake user contains is made with a UUID' do
+        uuid_regex = '[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}'
+        expect(create(:group).user.email).to match(/^test\+#{uuid_regex}@example.com$/i)
+      end
     end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Group, type: :model do
       it { should validate_uniqueness_of(:name) }
     end
 
-    describe 'number' do
-      it { should validate_presence_of(:number) }
-      it { should validate_uniqueness_of(:number) }
-      it { should validate_numericality_of(:number).is_greater_than_or_equal_to(1) }
-    end
-
     describe 'available votes' do
       it { should validate_presence_of(:available_votes) }
       it { should validate_numericality_of(:available_votes).is_greater_than_or_equal_to(1) }


### PR DESCRIPTION
### What

_Decide_ is going to be use by organizations where groups do not have an associated number. For this reason, this field should be made optional. 