### PR TITLE
Increase token duration to one week

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
          :jwt_authenticatable, jwt_revocation_strategy: JWTBlacklist
 
   AUTH_TOKEN_LENGTH = 6
-  AUTH_TOKEN_EXPIRATION_IN_DAYS = 2
+  AUTH_TOKEN_EXPIRATION_IN_DAYS = 7
 
   scope :with_valid_auth_token, -> { where('auth_token_expires_at > ?', Time.current) }
   scope :with_group, -> { joins(:group) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe User, type: :model do
       expect(create(:user).auth_token).to match(/^\d{6}$/)
     end
 
-    it 'expires after 48 hours' do
+    it 'expires after 7 days' do
       user = create :user
       expect(user.auth_token_expires_at).to be_between(
-        (Time.now + 2.days - 1.second),
-        (Time.now + 2.days + 1.second)
+        (Time.now + 7.days - 1.second),
+        (Time.now + 7.days + 1.second)
       )
     end
   end


### PR DESCRIPTION
### What

Normally we need to configure the authentication tokens during the week before the votings actually happen. Two days are not time enough to configure the tokens during working hours if the voting takes place on Sundays.