### PR TITLE
Fix error creating multiselect votings without options

### DIFF
--- a/app/models/multiselect_voting.rb
+++ b/app/models/multiselect_voting.rb
@@ -33,7 +33,7 @@ class MultiselectVoting < Voting
   private
 
   def handle_options
-    all_questions = options.split
+    all_questions = options&.split || []
     questions_already_present = questions.pluck(:title)
     questions_to_delete = questions_already_present - all_questions
     questions_to_create = all_questions - questions_already_present

--- a/spec/models/multiselect_voting_spec.rb
+++ b/spec/models/multiselect_voting_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe MultiselectVoting, type: :model do
       subject.update(options: "Foo\nBar\nFoobar")
       expect(subject.questions.pluck(:id)).to include(*existing_ids)
     end
+
+    it 'allows creation of votings with no options' do
+      expect(create(:multiselect_voting, options: nil)).to be_persisted
+    end
   end
 
   describe '#transform_votes' do


### PR DESCRIPTION
### What

An error occurs while creating multiselect votings without providing any option:

```
2020-05-06T22:48:15.519802+00:00 app[web.1]: [7e584834-5694-4dfd-b9b1-8d248a426612] NoMethodError (undefined method `split' for nil:NilClass):
2020-05-06T22:48:15.519803+00:00 app[web.1]: [7e584834-5694-4dfd-b9b1-8d248a426612]
2020-05-06T22:48:15.519804+00:00 app[web.1]: [7e584834-5694-4dfd-b9b1-8d248a426612] app/models/multiselect_voting.rb:36:in `handle_options'
2020-05-06T22:48:15.519804+00:00 app[web.1]: [7e584834-5694-4dfd-b9b1-8d248a426612] app/controllers/votings_controller.rb:36:in `create'
```