### PR TITLE
Fix incorrect split of options by space

### DIFF
--- a/app/models/multiselect_voting.rb
+++ b/app/models/multiselect_voting.rb
@@ -33,7 +33,7 @@ class MultiselectVoting < Voting
   private
 
   def handle_options
-    all_questions = options&.split || []
+    all_questions = options&.split("\n") || []
     questions_already_present = questions.pluck(:title)
     questions_to_delete = questions_already_present - all_questions
     questions_to_create = all_questions - questions_already_present

--- a/spec/models/multiselect_voting_spec.rb
+++ b/spec/models/multiselect_voting_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe MultiselectVoting, type: :model do
       expect(subject.questions.count).to eq 2
     end
 
+    it 'keeps multi-word options together' do
+      expect(create(:multiselect_voting, options: "Foo Bar\nFooBar").questions.pluck(:title)).to contain_exactly('Foo Bar', 'FooBar')
+    end
+
     it 'the options created have Yes/No choices' do
       expect(subject.questions.first.options.pluck(:title)).to contain_exactly('Yes', 'No')
     end


### PR DESCRIPTION
### What

Multiselect votings are incorrectly separating options by words in addition to by lines