### PR TITLE
Stop displaying info about the sense of the votes emitted

### DIFF
--- a/app/views/votings/_question_results.html.erb
+++ b/app/views/votings/_question_results.html.erb
@@ -4,7 +4,6 @@
 <%= panel_row column_class: 'col-sm-6' do %>
   <%= panel heading: t('results') do %>
     <%= question_results_table(question) %>
-    <%= alert_box "#{t('you_voted')}: #{question_group_summary(question)}", context: :success %>
   <% end %>
 
   <%= panel heading: t('bar_chart') do %>


### PR DESCRIPTION
### What

Information about the vote emitted is redundant in non-secret votings, and misleading in secret ones.