### PR TITLE
Use ordered lists in the voting resusts page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   def string_list(items)
     return unless items.present?
 
-    content_tag(:ul) do
+    content_tag(:ol) do
       items.map do |group_name|
         content_tag(:li) { group_name }
       end.inject(:+)


### PR DESCRIPTION
### What

The voting results page contains a list of the groups that have already voted and those that have not voted yet. However, when the list os long it is hard to know how many groups are pending to vote.