### PR TITLE
Indicate that the user has already voted with a green friendly message

### DIFF
--- a/app/views/votings/show.html.erb
+++ b/app/views/votings/show.html.erb
@@ -22,7 +22,7 @@
 
 <% if @voting.open? || @voting.ready?  %>
   <% if current_group&.voted?(@voting) %>
-    <%= alert_box t('already_voted_message'), context: :danger %>
+    <%= alert_box t('already_voted_message'), context: :success %>
     <%= button_to t('reload'), voting_path(@voting), class: 'b', form_class: 'f', method: :get, context: :primary %>
   <% else %>
     <%= render 'vote_submission_form', voting: @voting if can?(:vote, @voting) %>

--- a/cypress/integration/votings/vote.spec.js
+++ b/cypress/integration/votings/vote.spec.js
@@ -65,13 +65,13 @@ context('Vote submission', () => {
     cy.get('.total-votes-counter').should('contain', '5/5')
     cy.get('body').contains('Emitir votos').click()
 
-    cy.get('.alert.alert-danger').should('contain', 'Tu papeleta ha sido enviada. En cuanto se cierre la urna virtual podrás ver los resultados.')
+    cy.get('.alert.alert-success').should('contain', 'Tu papeleta ha sido enviada. En cuanto se cierre la urna virtual podrás ver los resultados.')
   })
 
   it('stay on the same page on reload', () => {
     cy.contains('Recargar').click()
 
-    cy.get('.alert.alert-danger').should('contain', 'Tu papeleta ha sido enviada. En cuanto se cierre la urna virtual podrás ver los resultados.')
+    cy.get('.alert.alert-success').should('contain', 'Tu papeleta ha sido enviada. En cuanto se cierre la urna virtual podrás ver los resultados.')
   })
 
   it('shows results once voting is finished', () => {


### PR DESCRIPTION
### What

The message that indicates that a user has already voted was red, which should be reserved for errors or dangerous operations. The style has now changed to the green "success" one.