### PR TITLE
Reorder voting dropdown to match the chronological order

### DIFF
--- a/app/models/voting.rb
+++ b/app/models/voting.rb
@@ -3,8 +3,8 @@
 class Voting < ApplicationRecord
   enum status: {
     draft: 0,
-    open: 1,
     ready: 3,
+    open: 1,
     finished: 2,
     archived: 4
   }


### PR DESCRIPTION
### What

The normal workflow of votings is: 

1. Draft
1. Ready
1. Open
1. Finished
1. Archived

However, the status dropdown in the voting form was displaying _open_ before _ready_, which is a bit confusing. This PR swaps those elements in the `enum` definition, which affects the way the dropdown is generated.