### PR TITLE
Configure segure flag for devise session

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -162,7 +162,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = {secure: true}
 
   # ==> Configuration for :validatable
   # Range for password length.


### PR DESCRIPTION
### What

We want to configure the _secure_ flag to session cookies to make sure they only travel through HTTPS connections.