### PR TITLE
Remove runtime middleware to avoid timing attacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ module Decide
       g.factory_bot suffix: "factory"
     end
 
+    config.middleware.delete(Rack::Runtime)
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'


### PR DESCRIPTION
### What

Remove runtime middleware to avoid timing attacks using the `x-runtime` header. Reference: https://www.virtuesecurity.com/kb/x-runtime-header-timing-attacks/