### PR TITLE
Fix error running spec in a different timezone

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe User, type: :model do
     it 'expires after 7 days' do
       user = create :user
       expect(user.auth_token_expires_at).to be_between(
-        (Time.now + 7.days - 1.second),
-        (Time.now + 7.days + 1.second)
+        (Time.now.utc + 7.days - 1.second),
+        (Time.now.utc + 7.days + 1.second)
       )
     end
   end


### PR DESCRIPTION
### What

There is one test that is failing locally because it is using the host's timezone

```
Failures:

  1) User auth_token expires after 7 days
     Failure/Error:
       expect(user.auth_token_expires_at).to be_between(
         (Time.now + 7.days - 1.second),
         (Time.now + 7.days + 1.second)
       )
     
       expected 2020-10-30 15:53:51.450677061 +0000 to be between 2020-10-30 17:53:50.452744391 +0100 and 2020-10-30 17:53:52.452860699 +0100 (inclusive)
     # ./spec/models/user_spec.rb:25:in `block (3 levels) in <top (required)>'

```