### PR TITLE
Configure default host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,9 @@ Rails.application.configure do
     authentication:       'plain',
     enable_starttls_auto: true
   }
+
+  config.action_mailer.default_url_options = {
+    host: ENV['DECIDE_HOST'],
+    protocol: 'https'
+  }
 end


### PR DESCRIPTION
### What

We need to configure a default host for email delivery:

```
ActionView::Template::Error: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true
```