### PR TITLE
Fix error joining available votes in email

### DIFF
--- a/app/helpers/mail_helper.rb
+++ b/app/helpers/mail_helper.rb
@@ -10,6 +10,6 @@ module MailHelper
   def plain_mail_vote_distribution(group)
     group.organization.bodies.map do |body|
       "- #{body.name}: #{group.votes_in_body(body)}"
-    end.inject("\n")
+    end.join("\n")
   end
 end


### PR DESCRIPTION
### What

Fix an error generating the email for groups:

```
2020-10-29T23:33:39.607Z pid=1 tid=pf1 WARN: /app/app/helpers/mail_helper.rb:13:in `each'
/app/app/helpers/mail_helper.rb:13:in `inject'
/app/app/helpers/mail_helper.rb:13:in `plain_mail_vote_distribution'
/app/app/views/group_mailer/code_submission.es.text.erb:7:in `_app_views_group_mailer_code_submission_es_text_erb___1562117738975366436_33500'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/base.rb:274:in `_run'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/template.rb:185:in `block in render'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:182:in `instrument'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/template.rb:385:in `instrument_render_template'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/template.rb:183:in `render'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/template_renderer.rb:58:in `block (2 levels) in render_template'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/abstract_renderer.rb:88:in `block in instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `block in instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `instrument'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/abstract_renderer.rb:87:in `instrument'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/template_renderer.rb:57:in `block in render_template'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/template_renderer.rb:65:in `render_with_layout'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/template_renderer.rb:56:in `render_template'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/template_renderer.rb:13:in `render'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/renderer.rb:61:in `render_template_to_object'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/renderer/renderer.rb:29:in `render_to_object'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/rendering.rb:117:in `block in _render_template'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/base.rb:304:in `in_rendering_context'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/rendering.rb:116:in `_render_template'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/rendering.rb:103:in `render_to_body'
/usr/local/bundle/gems/actionpack-6.0.3.4/lib/abstract_controller/rendering.rb:25:in `render'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/base.rb:958:in `block in collect_responses_from_block'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/collector.rb:28:in `custom'
/usr/local/bundle/gems/actionpack-6.0.3.4/lib/abstract_controller/collector.rb:11:in `text'
/app/app/mailers/group_mailer.rb:8:in `block in code_submission'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/base.rb:959:in `collect_responses_from_block'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/base.rb:948:in `collect_responses'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/base.rb:858:in `mail'
/app/app/mailers/group_mailer.rb:6:in `code_submission'
/usr/local/bundle/gems/actionpack-6.0.3.4/lib/abstract_controller/base.rb:195:in `process_action'
/usr/local/bundle/gems/actionpack-6.0.3.4/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:101:in `run_callbacks'
/usr/local/bundle/gems/actionpack-6.0.3.4/lib/abstract_controller/callbacks.rb:41:in `process_action'
/usr/local/bundle/gems/actionpack-6.0.3.4/lib/abstract_controller/base.rb:136:in `process'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/rescuable.rb:25:in `block in process'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/rescuable.rb:17:in `handle_exceptions'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/rescuable.rb:24:in `process'
/usr/local/bundle/gems/actionview-6.0.3.4/lib/action_view/rendering.rb:39:in `process'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/base.rb:637:in `block in process'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `block in instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `instrument'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/base.rb:636:in `process'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/parameterized.rb:143:in `block in processed_mailer'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/parameterized.rb:141:in `tap'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/parameterized.rb:141:in `processed_mailer'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/message_delivery.rb:114:in `deliver_now'
/usr/local/bundle/gems/actionmailer-6.0.3.4/lib/action_mailer/parameterized.rb:127:in `perform'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/execution.rb:40:in `block in perform_now'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
/usr/local/bundle/gems/i18n-1.8.5/lib/i18n.rb:313:in `with_locale'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/translation.rb:9:in `block (2 levels) in <module:Translation>'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `instance_exec'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/timezones.rb:9:in `block (2 levels) in <module:Timezones>'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `instance_exec'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/logging.rb:25:in `block (4 levels) in <module:Logging>'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `block in instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `instrument'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/logging.rb:24:in `block (3 levels) in <module:Logging>'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/logging.rb:45:in `block in tag_logger'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/tagged_logging.rb:80:in `block in tagged'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/tagged_logging.rb:28:in `tagged'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/tagged_logging.rb:80:in `tagged'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/logging.rb:45:in `tag_logger'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/logging.rb:21:in `block (2 levels) in <module:Logging>'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `instance_exec'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:139:in `run_callbacks'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/execution.rb:39:in `perform_now'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/execution.rb:25:in `block in execute'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/railtie.rb:43:in `block (4 levels) in <class:Railtie>'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/execution_wrapper.rb:88:in `wrap'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/reloader.rb:72:in `block in wrap'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/execution_wrapper.rb:84:in `wrap'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/reloader.rb:71:in `wrap'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/railtie.rb:42:in `block (3 levels) in <class:Railtie>'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `instance_exec'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:139:in `run_callbacks'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/execution.rb:23:in `execute'
/usr/local/bundle/gems/activejob-6.0.3.4/lib/active_job/queue_adapters/sidekiq_adapter.rb:42:in `perform'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:196:in `execute_job'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:164:in `block (2 levels) in process'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:163:in `block in process'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:136:in `block (6 levels) in dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/job_retry.rb:111:in `local'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:135:in `block (5 levels) in dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/rails.rb:14:in `block in call'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/execution_wrapper.rb:88:in `wrap'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/reloader.rb:72:in `block in wrap'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/execution_wrapper.rb:88:in `wrap'
/usr/local/bundle/gems/activesupport-6.0.3.4/lib/active_support/reloader.rb:71:in `wrap'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/rails.rb:13:in `call'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:131:in `block (4 levels) in dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:257:in `stats'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:126:in `block (3 levels) in dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/job_logger.rb:13:in `call'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:125:in `block (2 levels) in dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/job_retry.rb:78:in `global'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:124:in `block in dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/logger.rb:10:in `with'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/job_logger.rb:33:in `prepare'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:123:in `dispatch'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:162:in `process'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:78:in `process_one'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/processor.rb:68:in `run'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/util.rb:15:in `watchdog'
/usr/local/bundle/gems/sidekiq-6.1.2/lib/sidekiq/util.rb:24:in `block in safe_thread'
```