### PR TITLE
Use organization name in emails signature

### DIFF
--- a/app/mailers/group_mailer.rb
+++ b/app/mailers/group_mailer.rb
@@ -3,6 +3,7 @@ class GroupMailer < ApplicationMailer
     attachments.inline['logo.png'] = File.read('app/assets/images/logo.png')
 
     @group = params[:group]
+    @organization = @group.organization
     mail(to: @group.email, subject: t('mailers.groups.code_submission.subject')) do |format|
       format.html
       format.text

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -21,6 +21,6 @@
 
     <hr>
 
-    <p>Exploradores de Madrid</p>
+    <p><%= @organization.name %></p>
   </body>
 </html>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -2,4 +2,4 @@
 
 --
 
-Exploradores de Madrid
+<%= @organization.name %>


### PR DESCRIPTION
### What

We want to change the email signature using the organization name instead of a fixed "Exploradores de Madrid".