### PR TITLE
Use number of votes in the specific body

### DIFF
--- a/app/helpers/options_helper.rb
+++ b/app/helpers/options_helper.rb
@@ -10,17 +10,17 @@ module OptionsHelper
                     type: :range,
                     class: 'custom-range col-md-7 col-sm-10 col-10',
                     min: 0,
-                    max: (current_group&.available_votes || 10),
+                    max: (votes_available(option.question) || 10),
                     value: 0) +
         content_tag(:span, '0', class: 'counter col-2')
     end
   end
 
-  def total_votes_counter
+  def total_votes_counter(question)
     content_tag(:hr) +
       content_tag(:div, class: 'vote-summary') do
         content_tag(:label, t('votes.total'), class: 'col-md-10 col-sm-10 col-10') +
-          content_tag(:span, "0/#{current_group&.available_votes || 0}", class: 'total-votes-counter col-2', data: {total: current_group&.available_votes || 0})
+          content_tag(:span, "0/#{votes_available(question) || 0}", class: 'total-votes-counter col-2', data: {total: votes_available(question) || 0})
       end
   end
 end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -48,9 +48,10 @@ module QuestionsHelper
   end
 
   def question_input_form(f, question)
-    if current_group&.available_votes.to_i > 1
-      question.options.map { |option| range_for_option(f, option) }.inject(:+) + total_votes_counter
-    elsif current_group&.available_votes == 1
+    votes_available = votes_available(question)
+    if votes_available > 1
+      question.options.map { |option| range_for_option(f, option) }.inject(:+) + total_votes_counter(question)
+    elsif votes_available == 1
       f.collection_select :status, question.options, :id, :title, { include_blank: '' }, class: 'form-control', name: "votes[#{question.id}]"
     end
   end
@@ -62,6 +63,10 @@ module QuestionsHelper
         .count
         .map { |k, v| "#{k} (#{v} votos)" }
         .join(', ')
+  end
+
+  def votes_available(question)
+    current_group.votes_in_body(question.body)
   end
 
   private

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,6 +22,6 @@ class Organization < ApplicationRecord
   end
 
   def create_admin_account
-    users.create!(email: admin_email, role: :admin, password: admin_password)
+    users.create!(email: admin_email, role: :admin, password: admin_password) if admin_email && admin_password
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,4 +6,6 @@ class Question < ApplicationRecord
   accepts_nested_attributes_for :options, reject_if: :all_blank, allow_destroy: true
 
   validates_presence_of :title
+
+  delegate :body, to: :voting
 end

--- a/app/views/votings/_vote_submission_form.html.erb
+++ b/app/views/votings/_vote_submission_form.html.erb
@@ -10,6 +10,6 @@
       <%= alert_box t('errors.voting_not_open'), context: :warning if @voting.ready?%>
       <%= voting_questions_form(voting, f) %>
       <%= f.submit 'Emitir votos', disabled: @voting.ready? %>
-    <% end %>
+    <% end if current_group %>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,7 @@ Organization.destroy_all
 
 edm_org = Organization.find_or_create_by(name: 'Exploradores de Madrid')
 sample_org = Organization.find_or_create_by(name: 'Sample organization')
+Body.update_all(default_votes: 5)
 
 [[edm_org, 'edm'], [sample_org, 'sample']]. each do |(org, org_name)|
   %i[admin superadmin].each do |role|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ sample_org = Organization.find_or_create_by(name: 'Sample organization')
     end
   end
 
-  MAX_VOTES = 6
+  max_votes = 6
 
   groups = [
     ['Group 1', 1],
@@ -39,8 +39,8 @@ sample_org = Organization.find_or_create_by(name: 'Sample organization')
     Group.find_or_create_by!(organization: org, number: number) do |group|
       group.name = "#{name.downcase.capitalize} #{org.name}"
       group.email = "group-#{number}@#{org.name.downcase.gsub(' ', '')}.com.invalid"
-      group.available_votes = 1 + rand(MAX_VOTES - 1)
-    end
+      group.available_votes = 1
+    end.tap{ |g| g.assign_votes_to_body_by_name(org.name, 1 + rand(max_votes - 1)) }
   end
 
   public_voting = Voting.find_or_create_by!(organization: org, title: "#{org.name} - Weather voting") do |voting|
@@ -67,7 +67,7 @@ sample_org = Organization.find_or_create_by(name: 'Sample organization')
     response = public_voting.questions.map do |question|
       [
         question.id,
-        group.available_votes.times.map { question.option_ids.sample }.group_by(&:itself).transform_values(&:count)
+        group.votes_in_body(question.body).times.map { question.option_ids.sample }.group_by(&:itself).transform_values(&:count)
       ]
     end.to_h
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "cy:run:recorded": "cypress run --record",
     "cy:run": "cypress run",
-    "cy:open" : "cypress open"
+    "cy:open": "cypress open"
   },
   "snyk": true
 }

--- a/spec/services/vote_submission_service_spec.rb
+++ b/spec/services/vote_submission_service_spec.rb
@@ -3,8 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe VoteSubmissionService, type: :service do
-  let!(:group) { create :group, available_votes: 2 }
-  let!(:voting) { create :voting }
+  let!(:organization) { create :organization }
+  let!(:group) do
+    create(:group, available_votes: 2, organization: organization).tap do |g| 
+      g.assign_votes_to_body_by_name(organization.name, 2)
+    end
+  end
+  let!(:voting) { create :voting, organization: organization }
   let!(:question_1) { create :question, voting: voting }
   let!(:option_1_1) { create :option, question: question_1 }
   let!(:option_1_2) { create :option, question: question_1 }


### PR DESCRIPTION
### What

Organizations now support multiple decision-making bodies, each of them with a different number of votes available per group. We should no longer use the available votes configured at the group level.