### PR TITLE
Remove votes column

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -80,7 +80,7 @@ class GroupsController < ApplicationController
   private
 
   def group_params
-    params.require(:group).permit(:name, :number, :available_votes, :email, bodies_groups_attributes: [:id, :votes])
+    params.require(:group).permit(:name, :number, :email, bodies_groups_attributes: [:id, :votes])
   end
 
   def bulk_upload_params

--- a/app/helpers/votings_helper.rb
+++ b/app/helpers/votings_helper.rb
@@ -68,7 +68,7 @@ module VotingsHelper
       voting.questions.map do |question|
         f.check_box :options,
                     { label: question.title, name: "votes[#{question.id}][#{question.options.yes.first.id}]" },
-                    current_group.available_votes, 0
+                    votes_available(question), 0
       end.inject(:+)
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,8 +9,7 @@ class Group < ApplicationRecord
   accepts_nested_attributes_for :bodies_groups
 
   # Validations
-  validates_presence_of :name, :available_votes
-  validates_numericality_of :available_votes, greater_than_or_equal_to: 1
+  validates_presence_of :name
   validates :email,
             format: { with: URI::MailTo::EMAIL_REGEXP, message: I18n.t('activerecord.errors.email.invalid_format') },
             allow_blank: true

--- a/app/services/csv_group_importer.rb
+++ b/app/services/csv_group_importer.rb
@@ -18,7 +18,7 @@ class CsvGroupImporter
       @csv.each_with_index.map do |row, j|
         row_number = j + 1
         group = Group.find_or_initialize_by(organization: @organization, id: row[0])
-        group.update!(name: row[1], number: row[2], email: row[3], available_votes: 1)
+        group.update!(name: row[1], number: row[2], email: row[3])
 
         body_names.each_with_index do |body_name, i|
           group.assign_votes_to_body_by_name(

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -4,8 +4,6 @@
   <%= f.text_field :email %>
   <%= f.number_field :number %>
 
-  <%= f.text_field :available_votes %>
-
   <% if @group.persisted? %>
     <h3><%= t('activerecord.attributes.group.available_votes') %></h3>
     <div class="options-form">

--- a/config/locales/en/activerecord.en.yml
+++ b/config/locales/en/activerecord.en.yml
@@ -7,7 +7,6 @@ en:
       group:
         name: Name
         number: Number
-        available_votes: Available votes
         auth_token: Access token
         last_login: Last login
         email: Email

--- a/cypress/integration/groups/create_group_spec.js
+++ b/cypress/integration/groups/create_group_spec.js
@@ -31,11 +31,4 @@ context('Group creation', () => {
 
     cy.get('span').should('contain', 'can\'t be blank')
   })
-
-  it('return an error when available votes is 0', () => {
-    cy.get('#group_available_votes').clear().type('0')
-    cy.contains('Submit').click()
-
-    cy.get('span').should('contain', 'must be greater than or equal to 1')
-  })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,7 +24,6 @@ Cypress.Commands.add('fillGroupForm', (name) => {
   cy.get('#new_group').contains('Name').click().type(name)
   cy.contains('Email').click().type(`group-${name.toLowerCase().replaceAll(' ', '_')}@test.com.invalid`)
   cy.contains('Number').click().type('123')
-  cy.contains('Available votes').click().type('5')
 })
 
 Cypress.Commands.add('fillOrganizationForm', (name) => {

--- a/db/migrate/20201113172351_remove_votes_column.rb
+++ b/db/migrate/20201113172351_remove_votes_column.rb
@@ -1,0 +1,5 @@
+class RemoveVotesColumn < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :groups, :available_votes, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_160349) do
+ActiveRecord::Schema.define(version: 2020_11_13_172351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,7 +36,6 @@ ActiveRecord::Schema.define(version: 2020_10_23_160349) do
   create_table "groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.integer "number"
-    t.integer "available_votes", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,6 @@ Body.update_all(default_votes: 5)
     Group.find_or_create_by!(organization: org, number: number) do |group|
       group.name = "#{name.downcase.capitalize} #{org.name}"
       group.email = "group-#{number}@#{org.name.downcase.gsub(' ', '')}.com.invalid"
-      group.available_votes = 1
     end.tap{ |g| g.assign_votes_to_body_by_name(org.name, 1 + rand(max_votes - 1)) }
   end
 

--- a/spec/factories/groups_factory.rb
+++ b/spec/factories/groups_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :group do
     sequence(:name) { |n| "Group_#{n}" }
     sequence(:number) { |n| n }
-    available_votes { 1 }
     organization
 
     trait(:invalid) { name { nil } }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe Group, type: :model do
       it { should validate_presence_of(:name) }
     end
 
-    describe 'available votes' do
-      it { should validate_presence_of(:available_votes) }
-      it { should validate_numericality_of(:available_votes).is_greater_than_or_equal_to(1) }
-    end
-
     describe 'email' do
       it { expect(build(:group, email: 'foo@bar@bar.com')).not_to be_valid }
       it { expect(build(:group, email: 'foo@bar.com')).to be_valid }

--- a/spec/services/vote_submission_service_spec.rb
+++ b/spec/services/vote_submission_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe VoteSubmissionService, type: :service do
   let!(:organization) { create :organization }
   let!(:group) do
-    create(:group, available_votes: 2, organization: organization).tap do |g| 
+    create(:group, organization: organization).tap do |g|
       g.assign_votes_to_body_by_name(organization.name, 2)
     end
   end


### PR DESCRIPTION
### What

Now that the application supports multiple decision-making bodies, it no longer makes sense to use the `available_votes` column in the Group model. It can be destroyed along with all usages.