### PR TITLE
Add a migration to remove the uniqueness db constraint on group name

### DIFF
--- a/db/migrate/20201113182415_remove_database_uniqueness_constraints.rb
+++ b/db/migrate/20201113182415_remove_database_uniqueness_constraints.rb
@@ -1,0 +1,5 @@
+class RemoveDatabaseUniquenessConstraints < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :groups, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_172351) do
+ActiveRecord::Schema.define(version: 2020_11_13_182415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_11_13_172351) do
     t.uuid "user_id"
     t.uuid "organization_id"
     t.string "email"
-    t.index ["name"], name: "index_groups_on_name", unique: true
     t.index ["organization_id"], name: "index_groups_on_organization_id"
     t.index ["user_id"], name: "index_groups_on_user_id", unique: true
   end


### PR DESCRIPTION
### What

When the constraint to allow multiple groups with the same name was removed, we forgot to remove the BD constraint

```
ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_groups_on_name"
```