### PR TITLE
Fix countdown issues

### DIFF
--- a/app/models/voting.rb
+++ b/app/models/voting.rb
@@ -44,7 +44,9 @@ class Voting < ApplicationRecord
   def spawn_timeout_worker
     self.finishes_at = nil
     return if timeout_in_seconds.to_i.zero?
-    return unless status_changed?(from: 'ready', to: 'open') || status_changed?(from: 'draft', to: 'open')
+    return unless status_changed?(from: 'ready', to: 'open') ||
+                  status_changed?(from: 'draft', to: 'open') ||
+                  status_changed?(from: 'finished', to: 'open')
 
     VotingTimeoutUpdater.perform_in(timeout_in_seconds.seconds, id)
     self.finishes_at = timeout_in_seconds.seconds.from_now

--- a/app/views/votings/_countdown_component.html.erb
+++ b/app/views/votings/_countdown_component.html.erb
@@ -6,9 +6,9 @@
         <th colspan=3 scope="colgroup"><%= t('votings.voting_time') %></th>
       </tr>
       <tr class="timer-content">
-        <td class="countdown-min"><%= minutes_timeout(voting).to_s.rjust(2, '0') %></td>
+        <td class="countdown-min">-</td>
         <td>:</td>
-        <td class="countdown-sec"><%= seconds_timeout(voting).to_s.rjust(2, '0')  %></td>
+        <td class="countdown-sec">-</td>
       </tr>
       <tr>
         <td><%= t('time.minutes') %></td>

--- a/app/views/votings/_vote_submission_form.html.erb
+++ b/app/views/votings/_vote_submission_form.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <% if @voting.timeout_in_seconds %>
+  <% if @voting.timeout_in_seconds.positive? %>
     <div class="col-sm-3">
       <%= render 'countdown_component', voting: @voting %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  authenticate :user, lambda { |u| u.superadmin? } do
+  authenticate :user, lambda { |u| Rails.env.development? || u.superadmin? } do
     mount Sidekiq::Web => '/sidekiq'
   end
 

--- a/spec/models/voting_spec.rb
+++ b/spec/models/voting_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Voting, type: :model do
       end
     end
 
-    %i[draft ready].each do |from|
+    %i[draft ready finished].each do |from|
       context "transition '#{from.capitalize}' -> 'Open'" do
         context 'when the timeout is configured' do
           let(:voting) { create :voting, status: from, timeout_in_seconds: 60 }
@@ -67,8 +67,8 @@ RSpec.describe Voting, type: :model do
       end
     end
 
-    context "transition 'Finished' -> 'Open" do
-      let(:voting) { create :voting, status: :finished, timeout_in_seconds: 60 }
+    context "transition 'Archived' -> 'Open" do
+      let(:voting) { create :voting, status: :archived, timeout_in_seconds: 60 }
       include_examples 'do not spawn job'
     end
   end


### PR DESCRIPTION
### What

There are some issues related to the countdown component. Specifically, this PR fixes:

* Display the countdown component only in those votings that have a timeout configured.
* Re-enable the countdown timer when there is a voting transition from finished to open.
* Enable Sidekiq view in the development environment.
* Remove misleading timeout information when the component is first loaded.
