### PR TITLE
Warn about misconfigured votings

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -50,7 +50,7 @@ body {
 .fa {
   margin: 0 5px;
   font-size: 20px !important;
-  .warning {
+  &.warning {
     color: #ffc107;
   }
 }

--- a/app/helpers/votings_helper.rb
+++ b/app/helpers/votings_helper.rb
@@ -11,7 +11,7 @@ module VotingsHelper
       votings.each do |voting|
         row = []
         row << voting.body&.name
-        row << link_to(voting.title, organization_voting_path(voting.organization, voting)) + voting_badge(voting)
+        row << link_to(voting.title, organization_voting_path(voting.organization, voting)) + voting_badge(voting) + voting_warning(voting)
         row << voting_actions(voting)
         table.rows << row
       end
@@ -27,6 +27,12 @@ module VotingsHelper
       archived: :dark
     }[voting.status.to_sym] || :default
     content_tag(:span, t("activerecord.attributes.voting.statuses.#{voting.status}"), class: "badge badge-#{status}")
+  end
+
+  def voting_warning(voting)
+    return content_tag :span unless voting.misconfigured?
+
+    fa_icon('exclamation-triangle', t('activerecord.errors.voting.misconfigured'), class: :warning)
   end
 
   def voting_actions(voting)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -8,4 +8,8 @@ class Question < ApplicationRecord
   validates_presence_of :title
 
   delegate :body, to: :voting
+
+  def misconfigured?
+    options.count < 2
+  end
 end

--- a/app/models/voting.rb
+++ b/app/models/voting.rb
@@ -39,6 +39,11 @@ class Voting < ApplicationRecord
 
   def perform_voting_validations!(votes); end
 
+  def misconfigured?
+    return true if questions.none?
+    questions.any?(&:misconfigured?)
+  end
+
   private
 
   def spawn_timeout_worker

--- a/config/locales/en/activerecord.en.yml
+++ b/config/locales/en/activerecord.en.yml
@@ -71,4 +71,4 @@ en:
         invalid_format: Format is invalid
         missing: Email is missing
       voting:
-        misconfigured: The voting is misconfigured. Please, make sure it has at least one question, and all questions have at least two options
+        misconfigured: The voting is misconfigured. Please, make sure it has at least one question and all questions have at least two options

--- a/config/locales/en/activerecord.en.yml
+++ b/config/locales/en/activerecord.en.yml
@@ -70,3 +70,5 @@ en:
       email:
         invalid_format: Format is invalid
         missing: Email is missing
+      voting:
+        misconfigured: The voting is misconfigured. Please, make sure it has at least one question, and all questions have at least two options

--- a/config/locales/es/activerecord.es.yml
+++ b/config/locales/es/activerecord.es.yml
@@ -72,4 +72,4 @@ es:
         invalid_format: El formato es incorrecto
         missing: Falta el correo
       voting:
-        misconfigured: La urna virtual no está configurada correctamente. Por favor, asegúrate de que tiene al menos una pregunta, y todas las preguntas tienen al menos dos opciones.
+        misconfigured: La urna virtual no está configurada correctamente. Por favor, asegúrate de que tiene al menos una pregunta y todas las preguntas tienen al menos dos opciones.

--- a/config/locales/es/activerecord.es.yml
+++ b/config/locales/es/activerecord.es.yml
@@ -71,3 +71,5 @@ es:
       email:
         invalid_format: El formato es incorrecto
         missing: Falta el correo
+      voting:
+        misconfigured: La urna virtual no está configurada correctamente. Por favor, asegúrate de que tiene al menos una pregunta, y todas las preguntas tienen al menos dos opciones.

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -8,4 +8,23 @@ RSpec.describe Question, type: :model do
       it { should validate_presence_of(:title) }
     end
   end
+
+  describe '#misconfigured?' do
+    let(:question) { create :question, voting: create(:voting) }
+
+    context 'when the question has no options' do
+      before { question.options.destroy_all }
+      it { expect(question).to be_misconfigured }
+    end
+
+    context 'when the question has just one option' do
+      before { question.options.create(title: :foo) }
+      it { expect(question).to be_misconfigured }
+    end
+
+    context 'when the question has no options' do
+      before { 2.times{ |i| question.options.create(title: "Option #{i}") } }
+      it { expect(question).not_to be_misconfigured }
+    end
+  end
 end

--- a/spec/models/voting_spec.rb
+++ b/spec/models/voting_spec.rb
@@ -20,6 +20,45 @@ RSpec.describe Voting, type: :model do
     end
   end
 
+  describe '#misconfigured?' do
+    let(:voting) { create :voting }
+
+    context 'when there are no questions' do
+      before { voting.questions.destroy_all }
+      it { expect(voting).to be_misconfigured }
+    end
+
+    context 'when there is one question that is misconfigured' do
+      before do
+        allow(voting.questions.create(title: :foo)).to receive(:misconfigured?).and_return(true)
+      end
+      it { expect(voting).to be_misconfigured }
+    end
+
+    context 'when there is one question that is properly configured' do
+      before do
+        allow(voting.questions.create(title: :foo)).to receive(:misconfigured?).and_return(false)
+      end
+      it { expect(voting).not_to be_misconfigured }
+    end
+
+    context 'when one of the multiple questions is misconfigured' do
+      before do
+        allow(voting.questions.create(title: :bar)).to receive(:misconfigured?).and_return(true)
+        allow(voting.questions.create(title: :bar)).to receive(:misconfigured?).and_return(false)
+      end
+      it { expect(voting).to be_misconfigured }
+    end
+
+    context 'when all of the multiple questions are properly configured' do
+      before do
+        allow(voting.questions.create(title: :bar)).to receive(:misconfigured?).and_return(false)
+        allow(voting.questions.create(title: :bar)).to receive(:misconfigured?).and_return(false)
+      end
+      it { expect(voting).not_to be_misconfigured }
+    end
+  end
+
   describe 'automatic transition to finished status' do
     RSpec.shared_examples 'do not spawn job' do
       it 'the job is not scheduled' do


### PR DESCRIPTION
### What

We need to make admins aware when a voting is misconfigured so that they fix it before opening it. A voting is considered to be misconfigured when any of the following conditions are met:

1. The voting has no questions.
1. Any of the questions has less than two options to choose from.

![image](https://user-images.githubusercontent.com/6988693/99441679-8313d100-2918-11eb-9faa-55f9116b2c50.png)
