### PR TITLE
Order votings by name

### DIFF
--- a/app/controllers/votings_controller.rb
+++ b/app/controllers/votings_controller.rb
@@ -6,7 +6,7 @@ class VotingsController < ApplicationController
 
   # GET /votings
   def index
-    all_votings = @organization.votings.accessible_by(current_ability).includes(:questions)
+    all_votings = @organization.votings.accessible_by(current_ability).includes(:questions).order(title: :asc)
     @non_archived_votings = all_votings.where.not(status: :archived)
     @archived_votings = @votings.archived
     respond_to do |format|


### PR DESCRIPTION
### What

The votings in the votings index did not have a specific order, so it was difficult to make them show up in the same order they are going to be opened.

We decided to order by name so that we can prepend the desired order to the title of the voting. In future developments, a date field may be added, which will take precedence over the title.