### PR TITLE
Add more options in the timeout dropdown

### DIFF
--- a/app/helpers/votings_helper.rb
+++ b/app/helpers/votings_helper.rb
@@ -93,7 +93,7 @@ module VotingsHelper
   end
 
   def timeout_in_seconds_for_select
-    [0, 30, 60, 300].map { |n| [n, t("activerecord.attributes.voting.timeout_options.#{n}_seconds")] }.to_h
+    [0, 30, 60, 120, 180, 300].map { |n| [n, t("activerecord.attributes.voting.timeout_options.#{n}_seconds")] }.to_h
   end
 
   def minutes_timeout(voting)

--- a/config/locales/en/activerecord.en.yml
+++ b/config/locales/en/activerecord.en.yml
@@ -36,6 +36,8 @@ en:
           0_seconds: Unlimited
           30_seconds: 30 seconds
           60_seconds: 1 minute
+          120_seconds: 2 minutes
+          180_seconds: 3 minutes
           300_seconds: 5 minutes
         secret: Secret
     models:

--- a/config/locales/es/activerecord.es.yml
+++ b/config/locales/es/activerecord.es.yml
@@ -37,6 +37,8 @@ es:
           0_seconds: Sin límite
           30_seconds: 30 segundos
           60_seconds: 1 minuto
+          120_seconds: 2 minutos
+          180_seconds: 3 minutos
           300_seconds: 5 minutos
         secret: Secreta
     models:


### PR DESCRIPTION
### What

There was a big gap between 1 minute and 5 minutes in the dropdown list for the countdown. This PR adds the 2-minute and 3-minute options