### PR TITLE
Remove deprecation warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ Bundler.require(*Rails.groups)
 module Decide
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,6 @@ module Decide
 
     config.time_zone = 'Madrid'
     config.active_record.default_timezone = :local
-    config.active_record.legacy_connection_handling = false
 
     config.active_job.queue_adapter     = :sidekiq
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,7 @@ module Decide
 
     config.time_zone = 'Madrid'
     config.active_record.default_timezone = :local
+    config.active_record.legacy_connection_handling = false
 
     config.active_job.queue_adapter     = :sidekiq
   end


### PR DESCRIPTION
Load Rails 7.0 defaults to remove deprecation warnings.